### PR TITLE
Feat/audacity labels

### DIFF
--- a/cuegen.py
+++ b/cuegen.py
@@ -65,7 +65,7 @@ class CueTrack():
         line = re.sub(f"(\\[|\\(|){match_time.group(1)}(\\]|\\)|)", "", line)
         artist = None
         title = None
-        for split in line.split("-"):
+        for split in line.split(" - "):
             if not artist:
                 artist = split.strip()
             elif not title:


### PR DESCRIPTION
I added the ability to parse Audacity label tracks. To use, in Audacity just create a label track, add some labels and export it as a text file.
cuegen will be able to read that file and create a cuesheet.
No new options were added, it's automatically detected if the source file is exported from Audacity. If not then cuegen acts the same as before.

Feel free to merge this!