### PR TITLE
Fix for missing `dateutil`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+python-dateutil

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         'Programming Language :: Python :: 3.4',
     ],
     packages = find_packages(),
+    install_requires = [ "python-dateutil" ],
     keywords='cue parser cdtool audio generator',
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
## Error

starting one of the tools, installed via `pipx`, with modern python (3.12), results in this error:

```python
❯ cuegen
Traceback (most recent call last):
  File "/Users/ic/.local/bin/cuegen", line 5, in <module>
    from cuegen import main
  File "/Users/ic/dev/.dotfiles/.local/share/pipx/venvs/cueparser/lib/python3.12/site-packages/cuegen.py", line 10, in <module>
    from dateutil.parser import parse
ModuleNotFoundError: No module named 'dateutil'
```

## Solution

Fixed by creating `requirements.txt` and applying changes to `setup.py`